### PR TITLE
fixed warning from use of deprecated `ONCE_INIT`

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -466,7 +466,7 @@ macro_rules! crate_version {
 macro_rules! crate_authors {
     ($sep:expr) => {{
         use std::ops::Deref;
-        use std::sync::{Once, ONCE_INIT};
+        use std::sync::Once;
 
         #[allow(missing_copy_implementations)]
         #[allow(dead_code)]
@@ -479,7 +479,7 @@ macro_rules! crate_authors {
 
             #[allow(unsafe_code)]
             fn deref(&self) -> &'static str {
-                static ONCE: Once = ONCE_INIT;
+                static ONCE: Once = Once::new();
                 static mut VALUE: *const String = 0 as *const String;
 
                 unsafe {


### PR DESCRIPTION
<!--
If your PR closes some issues, please write `Closes #XXXX`
where `XXXX` is the number of the issue you want to fix.
Each issue goes on it's own line.
-->
